### PR TITLE
There seems to be a bug in bs4/lxml callback, add 'strict' parameter

### DIFF
--- a/script.module.keyboard.chinese/lib/ChineseKeyboard.py
+++ b/script.module.keyboard.chinese/lib/ChineseKeyboard.py
@@ -423,7 +423,7 @@ class Keyboard:
         with open(os.path.join(skinpath, 'addon.xml')) as xmlfile:
             data = xmlfile.read()
         xmlfile.close()
-        soup = BeautifulSoup(data)
+        soup = BeautifulSoup(data, 'strict')
         it = soup.find('res', attrs={"aspect":aspect})
         folder = it.get('folder')
 
@@ -436,7 +436,7 @@ class Keyboard:
         with open(os.path.join(skinpath, folder, 'DialogKeyboard.xml')) as xmlfile:
             data = xmlfile.read()
         xmlfile.close()
-        soup = BeautifulSoup(data)
+        soup = BeautifulSoup(data, 'strict')
         it = soup.find('control', attrs={"type":"label", "id":CTL_LABEL_EDIT})
         if not it:
             it = soup.find('control', attrs={"type":"edit", "id":CTL_EDIT_EDIT})


### PR DESCRIPTION
There seems to be a bug in bs4/lxml callback, add 'strict' parameter to forcely overwrite it.
在*nix系统下，如果安装了lxml库，就会出现bs4解析错误。
简单加一行代码就可以重现
BeautifulSoup('''<html><a><d></d><b><c></c></b></a></html>''' =》 输出了None

考虑为kodi在调用基于c编译的lxml时，py回调函数中引用的c对象不存在。
在bs4/builder/_lxml.py的LXMLTreeBuilderForXML.start函数开头有一段
```python
attrs = dict(attrs)
```

attrs是lxml.etree._ImmutableMapping object 类型c对象
```
   Traceback (most recent call last):
                                              File "/home/jackyspy/.kodi/addons/script.module.beautifulsoup4/lib/bs4/builder/_lxml.py", line 131, in start
                                                attrs = dict(attrs)
                                              File "/usr/lib/python2.7/_abcoll.py", line 410, in keys
                                                return list(self)
                                            TypeError: 'NoneType' object is not callable
```