### PR TITLE
Fix no subtitles in the list for subhd and 163sub字幕下载修复

### DIFF
--- a/service.subtitles.163sub/service.py
+++ b/service.subtitles.163sub/service.py
@@ -137,6 +137,8 @@ def Download(id,lang):
         xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (tempfile,__temp__,)).encode('utf-8'), True)
     path = __temp__
     dirs, files = xbmcvfs.listdir(path)
+    if ('__MACOSX') in dirs:
+        dirs.remove('__MACOSX')
     if len(dirs) > 0:
         path = os.path.join(__temp__, dirs[0].decode('utf-8'))
         dirs, files = xbmcvfs.listdir(path)
@@ -150,7 +152,8 @@ def Download(id,lang):
         sel = xbmcgui.Dialog().select('请选择压缩包中的字幕', list)
         if sel == -1:
             sel = 0
-        subtitle_list.append(os.path.join(path, list[sel]))
+        if len(list):
+            subtitle_list.append(os.path.join(path, list[sel]))
 
     return subtitle_list
 

--- a/service.subtitles.subhd/service.py
+++ b/service.subtitles.subhd/service.py
@@ -154,6 +154,8 @@ def Download(url,lang):
         xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (zip,__temp__,)).encode('utf-8'), True)
     path = __temp__
     dirs, files = xbmcvfs.listdir(path)
+    if ('__MACOSX') in dirs:
+        dirs.remove('__MACOSX')
     if len(dirs) > 0:
         path = os.path.join(__temp__, dirs[0].decode('utf-8'))
         dirs, files = xbmcvfs.listdir(path)
@@ -167,7 +169,8 @@ def Download(url,lang):
         sel = xbmcgui.Dialog().select('请选择压缩包中的字幕', list)
         if sel == -1:
             sel = 0
-        subtitle_list.append(os.path.join(path, list[sel]))
+        if len(list):
+            subtitle_list.append(os.path.join(path, list[sel]))
 
     return subtitle_list
 


### PR DESCRIPTION
The problem is due to some hidden files in subtitle zip, especially in __MACOSX. If Kodi is not configured to show hidden files, it will not be able to delete __MACOSX folder, resulting no subtitles issue for any downloaded subs in the future. 

导致列表里没有字幕的原因是隐藏文件，尤其是一旦下载的字幕里有__MACOSX文件夹，那么以后下载的所有字幕都不能正常列出了。这个pull request修复了该问题。如果急用又不想手动更新，可以在kodi设置里打开显示隐藏文件，也能临时解决问题，缺点是有__MACOSX文件夹的字幕包无法正常显示，但至少其他的可以显示。