### PR TITLE
Fix Zimuku Base related url problem.

### DIFF
--- a/service.subtitles.zimuku/service.py
+++ b/service.subtitles.zimuku/service.py
@@ -120,7 +120,8 @@ def Search( item ):
 def DownloadLinks(links, referer):
     for link in links:
         url = link.get('href').encode('utf-8')
-        url = ZIMUKU_BASE + url
+        if not url.startswith('http'):
+            url = ZIMUKU_BASE + url
         try:
             log( sys._getframe().f_code.co_name ,"Download url: %s" % (url))
             req = urllib2.Request(url)


### PR DESCRIPTION
下载字幕一直下载不成功，看log发现了如下的错误。
由于没接触过Kodi Add-on开发，暂时只是从Python的角度把问题fix如下，并没有进行实际的测试。
后期有需要可以补齐其他相关的修改和测试。

```
2019-11-23 14:57:26.300 T:12076   DEBUG: zimuku::DownloadLinks - Download url: http://www.zimuku.lahttp://www.zimuku.la/download/XXXX
```